### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/lilith-roth/yrba/releases/tag/v1.0.1) - 2025-07-11
+
+### Added
+
+- base features ([#1](https://github.com/lilith-roth/yrba/pull/1))
+
+### Fixed
+
+- release not working due to broken license field
+- relative home paths did not work for config file ([#2](https://github.com/lilith-roth/yrba/pull/2))
+
+### Other
+
+- bump version for bugfix & release trigger
+- updated release-plz.toml to allow release on fix commits
+- binary release CD pipeline
+- release v1.0.0 ([#3](https://github.com/lilith-roth/yrba/pull/3))
+- release-plz integration
+- Initial commit
+
 ## [1.0.0](https://github.com/lilith-roth/yrba/releases/tag/v1.0.0) - 2025-07-11
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 1.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/lilith-roth/yrba/releases/tag/v1.0.1) - 2025-07-11

### Added

- base features ([#1](https://github.com/lilith-roth/yrba/pull/1))

### Fixed

- release not working due to broken license field
- relative home paths did not work for config file ([#2](https://github.com/lilith-roth/yrba/pull/2))

### Other

- bump version for bugfix & release trigger
- updated release-plz.toml to allow release on fix commits
- binary release CD pipeline
- release v1.0.0 ([#3](https://github.com/lilith-roth/yrba/pull/3))
- release-plz integration
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).