### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/lilith-roth/yrba/compare/v1.1.0...v1.1.1) - 2025-09-24
+
+### Fixed
+
+- memory allocation for upload
+
+### Other
+
+- typo in README.md
+
 ## [1.1.0](https://github.com/lilith-roth/yrba/compare/v1.0.1...v1.1.0) - 2025-07-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yrba"
 description = "Incremental remote backups made simple!"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 1.1.0 -> 1.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.1](https://github.com/lilith-roth/yrba/compare/v1.1.0...v1.1.1) - 2025-09-24

### Fixed

- memory allocation for upload

### Other

- typo in README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).