### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/lilith-roth/yrba/compare/v1.1.1...v1.1.2) - 2025-11-06
+
+### Fixed
+
+- temporary archives did not get deleted ([#10](https://github.com/lilith-roth/yrba/pull/10))
+
+### Other
+
+- *(gitignore)* minor gitignore update ([#13](https://github.com/lilith-roth/yrba/pull/13))
+- *(sftp upload)* minor code cleanup & impr. log msg ([#12](https://github.com/lilith-roth/yrba/pull/12))
+- *(sftp upload)* limited buffer size for SFTP uploads ([#8](https://github.com/lilith-roth/yrba/pull/8))
+- *(gitignore)* added working folders to gitignore ([#9](https://github.com/lilith-roth/yrba/pull/9))
+
 ## [1.1.1](https://github.com/lilith-roth/yrba/compare/v1.1.0...v1.1.1) - 2025-09-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yrba"
 description = "Incremental remote backups made simple!"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 1.1.1 -> 1.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.2](https://github.com/lilith-roth/yrba/compare/v1.1.1...v1.1.2) - 2025-11-06

### Fixed

- temporary archives did not get deleted ([#10](https://github.com/lilith-roth/yrba/pull/10))

### Other

- *(gitignore)* minor gitignore update ([#13](https://github.com/lilith-roth/yrba/pull/13))
- *(sftp upload)* minor code cleanup & impr. log msg ([#12](https://github.com/lilith-roth/yrba/pull/12))
- *(sftp upload)* limited buffer size for SFTP uploads ([#8](https://github.com/lilith-roth/yrba/pull/8))
- *(gitignore)* added working folders to gitignore ([#9](https://github.com/lilith-roth/yrba/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).