### PR TITLE
chore: release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/lilith-roth/yrba/compare/v1.1.2...v1.1.3) - 2025-11-06
+
+### Other
+
+- *(release-plz)* updated release pr config
+- *(docker)* moved command params to docker compose file ([#15](https://github.com/lilith-roth/yrba/pull/15))
+- explicit typing & improved logging ([#14](https://github.com/lilith-roth/yrba/pull/14))
+
 ## [1.1.2](https://github.com/lilith-roth/yrba/compare/v1.1.1...v1.1.2) - 2025-11-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yrba"
 description = "Incremental remote backups made simple!"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 1.1.2 -> 1.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.3](https://github.com/lilith-roth/yrba/compare/v1.1.2...v1.1.3) - 2025-11-06

### Other

- *(release-plz)* updated release pr config
- *(docker)* moved command params to docker compose file ([#15](https://github.com/lilith-roth/yrba/pull/15))
- explicit typing & improved logging ([#14](https://github.com/lilith-roth/yrba/pull/14))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).