### PR TITLE
chore: release v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.6](https://github.com/lilith-roth/yrba/compare/v1.1.5...v1.1.6) - 2025-11-10
+
+### Fixed
+
+- *(docs)* linking of index page
+
+### Other
+
+- *(flake.nix)* allow running on aarch64-darwin
+- *(TODO.md)* update todo
+- *(TODO.md)* update todo
+- *(readme.md)* added mention of the official documentation
+
 ## [1.1.5](https://github.com/lilith-roth/yrba/compare/v1.1.4...v1.1.5) - 2025-11-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yrba"
 description = "Incremental remote backups made simple!"
-version = "1.1.5"
+version = "1.1.6"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 1.1.5 -> 1.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.6](https://github.com/lilith-roth/yrba/compare/v1.1.5...v1.1.6) - 2025-11-10

### Fixed

- *(docs)* linking of index page

### Other

- *(flake.nix)* allow running on aarch64-darwin
- *(TODO.md)* update todo
- *(TODO.md)* update todo
- *(readme.md)* added mention of the official documentation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).