### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/lilith-roth/yrba/compare/v1.1.8...v1.2.0) - 2025-11-12
+
+### Added
+
+- systemd service & timers ([#38](https://github.com/lilith-roth/yrba/pull/38))
+
 ## [1.1.8](https://github.com/lilith-roth/yrba/compare/v1.1.7...v1.1.8) - 2025-11-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "1.1.8"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yrba"
 description = "Incremental remote backups made simple!"
-version = "1.1.8"
+version = "1.2.0"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 1.1.8 -> 1.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.0](https://github.com/lilith-roth/yrba/compare/v1.1.8...v1.2.0) - 2025-11-12

### Added

- systemd service & timers ([#38](https://github.com/lilith-roth/yrba/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).