### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/lilith-roth/yrba/compare/v1.3.0...v2.0.0) - 2025-11-13
+
+### Other
+
+- *(deps)* bump rust from 1.88-alpine3.22 to 1.91-alpine3.22 ([#51](https://github.com/lilith-roth/yrba/pull/51))
+- [**breaking**] implemented strict clippy checks & impr. abbrevations ([#45](https://github.com/lilith-roth/yrba/pull/45))
+- create dependabot.yml ([#49](https://github.com/lilith-roth/yrba/pull/49))
+- update for custom documentation domain
+- Update issue templates
+- Create FUNDING.yml
+- README.md cleanup
+- improve documentation
+- minor code improvement
+
 ## [1.3.0](https://github.com/lilith-roth/yrba/compare/v1.2.1...v1.3.0) - 2025-11-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yrba"
 description = "Incremental remote backups made simple!"
-version = "1.3.0"
+version = "2.0.0"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 1.3.0 -> 2.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/lilith-roth/yrba/compare/v1.3.0...v2.0.0) - 2025-11-13

### Other

- *(deps)* bump rust from 1.88-alpine3.22 to 1.91-alpine3.22 ([#51](https://github.com/lilith-roth/yrba/pull/51))
- [**breaking**] implemented strict clippy checks & impr. abbrevations ([#45](https://github.com/lilith-roth/yrba/pull/45))
- create dependabot.yml ([#49](https://github.com/lilith-roth/yrba/pull/49))
- update for custom documentation domain
- Update issue templates
- Create FUNDING.yml
- README.md cleanup
- improve documentation
- minor code improvement
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).