### PR TITLE
chore: release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/lilith-roth/yrba/compare/v2.0.0...v2.0.1) - 2025-11-14
+
+### Other
+
+- deb packaging ([#55](https://github.com/lilith-roth/yrba/pull/55))
+- packaging & PR binary builds ([#54](https://github.com/lilith-roth/yrba/pull/54))
+
 ## [2.0.0](https://github.com/lilith-roth/yrba/compare/v1.3.0...v2.0.0) - 2025-11-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yrba"
 description = "Incremental remote backups made simple!"
 authors = ["Lilith Roth <lilith@roth.systems>"]
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 2.0.0 -> 2.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.1](https://github.com/lilith-roth/yrba/compare/v2.0.0...v2.0.1) - 2025-11-14

### Other

- deb packaging ([#55](https://github.com/lilith-roth/yrba/pull/55))
- packaging & PR binary builds ([#54](https://github.com/lilith-roth/yrba/pull/54))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).