### PR TITLE
chore: release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2](https://github.com/lilith-roth/yrba/compare/v2.0.1...v2.0.2) - 2025-11-14
+
+### Other
+
+- binary deployments broken
+
 ## [2.0.1](https://github.com/lilith-roth/yrba/compare/v2.0.0...v2.0.1) - 2025-11-14
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yrba"
 description = "Incremental remote backups made simple!"
 authors = ["Lilith Roth <lilith@roth.systems>"]
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 2.0.1 -> 2.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.2](https://github.com/lilith-roth/yrba/compare/v2.0.1...v2.0.2) - 2025-11-14

### Other

- binary deployments broken
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).