### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/lilith-roth/yrba/compare/v2.0.2...v2.1.0) - 2025-11-17
+
+### Added
+
+- file copy backups ([#58](https://github.com/lilith-roth/yrba/pull/58))
+
+### Other
+
+- readme badges ([#62](https://github.com/lilith-roth/yrba/pull/62))
+- improve rust checks ([#60](https://github.com/lilith-roth/yrba/pull/60))
+
 ## [2.0.2](https://github.com/lilith-roth/yrba/compare/v2.0.1...v2.0.2) - 2025-11-14
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yrba"
 description = "Incremental remote backups made simple!"
 authors = ["Lilith Roth <lilith@roth.systems>"]
-version = "2.0.2"
+version = "2.1.0"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 2.0.2 -> 2.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.0](https://github.com/lilith-roth/yrba/compare/v2.0.2...v2.1.0) - 2025-11-17

### Added

- file copy backups ([#58](https://github.com/lilith-roth/yrba/pull/58))

### Other

- readme badges ([#62](https://github.com/lilith-roth/yrba/pull/62))
- improve rust checks ([#60](https://github.com/lilith-roth/yrba/pull/60))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).