### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1](https://github.com/lilith-roth/yrba/compare/v2.1.0...v2.1.1) - 2025-11-18
+
+### Other
+
+- improved error handling ([#66](https://github.com/lilith-roth/yrba/pull/66))
+
 ## [2.1.0](https://github.com/lilith-roth/yrba/compare/v2.0.2...v2.1.0) - 2025-11-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yrba"
 description = "Incremental remote backups made simple!"
 authors = ["Lilith Roth <lilith@roth.systems>"]
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 2.1.0 -> 2.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.1](https://github.com/lilith-roth/yrba/compare/v2.1.0...v2.1.1) - 2025-11-18

### Other

- improved error handling ([#66](https://github.com/lilith-roth/yrba/pull/66))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).