### PR TITLE
added a tmp docker volume 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix: added docker volume mounts 
+
 ## [2.1.1](https://github.com/lilith-roth/yrba/compare/v2.1.0...v2.1.1) - 2025-11-18
 
 ### Other

--- a/docker/docker-compose-cron.yml
+++ b/docker/docker-compose-cron.yml
@@ -13,4 +13,7 @@ services:
       - ../folder-to-backup:/backup
       - ../config.toml:/app/config.toml
       - ~/.ssh/:/auth
+      - tmp-data:/tmp
     command: ["/app/docker/cron_start.sh"]
+volumes:
+  tmp-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,3 +9,6 @@ services:
       - ../config.toml:/app/config.toml
       - ../folder-to-backup:/backup
       - ~/.ssh/:/auth
+      - tmp-data:/tmp
+volumes:
+  tmp-data:


### PR DESCRIPTION
#19 
Added a mounted volume 

Tested by creating a 10 gb Dir of non-sense with this python script 
```python
from pathlib import Path
import random
def _generate_random_files(size:int=100_000,num:int=100_000,dir:Path=Path("./tmp-test/")):
    dir.mkdir(parents=True,exist_ok=True)
    for i in range(num):
        file_name = f"file_{random.randint(0,num*100_000)}"
        content = random.randbytes(8) * (size//8)
        (dir/file_name).write_bytes(content)
_generate_random_files()
```
then ran 
`time docker run   --rm   --name yrba   -v ./config.toml:/app/config.toml   -v ./tmp-test:/backup   -v ~/.ssh/:/auth -v tmp-data:/tmp  dcpacky/yrba-official:latest   /app/release/yrba -c /app/config.toml`
<img width="1331" height="519" alt="prt2" src="https://github.com/user-attachments/assets/2eda767b-34d0-4480-810e-8e64237a6122" />

and 
`time docker run   --rm   --name yrba   -v ./config.toml:/app/config.toml   -v ./tmp-test:/backup   -v ~/.ssh/:/auth  dcpacky/yrba-official:latest   /app/release/yrba -c /app/config.toml`
<img width="1319" height="498" alt="prt1" src="https://github.com/user-attachments/assets/53dcd101-9cad-49ef-b6d2-4b92ef9f67dc" />

and saw no meaningful degradation in time performance between the two. 

checked that the tmp-data volume afterwards to verify deletion of tmp data 
<img width="335" height="167" alt="prt3" src="https://github.com/user-attachments/assets/6af0bb95-40e2-404d-a4b6-de314e53c0fd" />

also profiled container ram usage with these commands:

```bash
docker run --rm --name yrba \
  -v ./config.toml:/app/config.toml \
  -v ./tmp-test:/backup \
  -v ~/.ssh/:/auth \
  -d \
  dcpacky/yrba-official:latest \
  /app/release/yrba -c /app/config.toml && \
while docker ps | grep -q yrba; do \
    echo "$(date +%s),$(docker stats yrba --no-stream --format '{{.MemUsage}}')" >> memory_log.csv; \
    sleep 10; \
done
```
and 
```bash
docker run --rm --name yrba \
  -v ./config.toml:/app/config.toml \
  -v ./tmp-test:/backup \
  -v ~/.ssh/:/auth \
  -v tmp-data:/tmp \
  -d \
  dcpacky/yrba-official:latest \
  /app/release/yrba -c /app/config.toml && \
while docker ps | grep -q yrba; do \
    echo "$(date +%s),$(docker stats yrba --no-stream --format '{{.MemUsage}}')" >> memory_log.csv; \
    sleep 10; \
done
```
with the result:
```csv
1763836228,49.2MiB / 27.17GiB
1763836239,201.3MiB / 27.17GiB
1763836250,309.2MiB / 27.17GiB
1763836261,378.1MiB / 27.17GiB
1763836272,400.7MiB / 27.17GiB
1763836283,385.8MiB / 27.17GiB
1763836295,388.9MiB / 27.17GiB
```
and 
```csv
1763836523,103.3MiB / 27.17GiB
1763836534,192.1MiB / 27.17GiB
1763836545,260.4MiB / 27.17GiB
1763836556,313MiB / 27.17GiB
1763836567,299.3MiB / 27.17GiB
1763836578,300.8MiB / 27.17GiB
```
however I think this test might miss the memory spike expected because of the long polling interval. 
