### PR TITLE
chore: release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0](https://github.com/lilith-roth/yrba/compare/v2.1.1...v2.2.0) - 2025-11-27
+
+### Added
+
+- smb implementation ([#75](https://github.com/lilith-roth/yrba/pull/75))
+
+### Fixed
+
+- *(docker)* added a tmp docker volume  ([#77](https://github.com/lilith-roth/yrba/pull/77))
+
+### Other
+
+- macOS builds broken due to deprecated CI runner ([#85](https://github.com/lilith-roth/yrba/pull/85))
+- *(deps)* bump actions/upload-pages-artifact from 3 to 4 ([#81](https://github.com/lilith-roth/yrba/pull/81))
+- *(deps)* bump actions/checkout from 4 to 6 ([#82](https://github.com/lilith-roth/yrba/pull/82))
+- *(deps)* bump peter-evans/dockerhub-description from 4.0.0 to 5.0.0 ([#80](https://github.com/lilith-roth/yrba/pull/80))
+- *(deps)* bump actions/upload-artifact from 4 to 5 ([#79](https://github.com/lilith-roth/yrba/pull/79))
+- Two small docs changes ([#78](https://github.com/lilith-roth/yrba/pull/78))
+- *(deps)* bump docker/build-push-action from 4.0.0 to 6.18.0 ([#68](https://github.com/lilith-roth/yrba/pull/68))
+- *(deps)* bump docker/metadata-action from 9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 to 8d8c7c12f7b958582a5cb82ba16d5903cb27976a ([#71](https://github.com/lilith-roth/yrba/pull/71))
+- *(deps)* bump actions/configure-pages from 4 to 5 ([#70](https://github.com/lilith-roth/yrba/pull/70))
+- *(deps)* bump actions/attest-build-provenance from 2 to 3 ([#69](https://github.com/lilith-roth/yrba/pull/69))
+
 - fix: added docker volume mounts 
 
 ## [2.1.1](https://github.com/lilith-roth/yrba/compare/v2.1.0...v2.1.1) - 2025-11-18

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yrba"
 description = "Incremental remote backups made simple!"
 authors = ["Lilith Roth <lilith@roth.systems>"]
-version = "2.1.1"
+version = "2.2.0"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 2.1.1 -> 2.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.2.0](https://github.com/lilith-roth/yrba/compare/v2.1.1...v2.2.0) - 2025-11-27

### Added

- smb implementation ([#75](https://github.com/lilith-roth/yrba/pull/75))

### Fixed

- *(docker)* added a tmp docker volume  ([#77](https://github.com/lilith-roth/yrba/pull/77))

### Other

- macOS builds broken due to deprecated CI runner ([#85](https://github.com/lilith-roth/yrba/pull/85))
- *(deps)* bump actions/upload-pages-artifact from 3 to 4 ([#81](https://github.com/lilith-roth/yrba/pull/81))
- *(deps)* bump actions/checkout from 4 to 6 ([#82](https://github.com/lilith-roth/yrba/pull/82))
- *(deps)* bump peter-evans/dockerhub-description from 4.0.0 to 5.0.0 ([#80](https://github.com/lilith-roth/yrba/pull/80))
- *(deps)* bump actions/upload-artifact from 4 to 5 ([#79](https://github.com/lilith-roth/yrba/pull/79))
- Two small docs changes ([#78](https://github.com/lilith-roth/yrba/pull/78))
- *(deps)* bump docker/build-push-action from 4.0.0 to 6.18.0 ([#68](https://github.com/lilith-roth/yrba/pull/68))
- *(deps)* bump docker/metadata-action from 9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 to 8d8c7c12f7b958582a5cb82ba16d5903cb27976a ([#71](https://github.com/lilith-roth/yrba/pull/71))
- *(deps)* bump actions/configure-pages from 4 to 5 ([#70](https://github.com/lilith-roth/yrba/pull/70))
- *(deps)* bump actions/attest-build-provenance from 2 to 3 ([#69](https://github.com/lilith-roth/yrba/pull/69))

- fix: added docker volume mounts
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).