### PR TITLE
chore: release v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2](https://github.com/lilith-roth/yrba/compare/v2.2.1...v2.2.2) - 2025-12-05
+
+### Fixed
+
+- *(systemd)* service description broken
+
 ## [2.2.1](https://github.com/lilith-roth/yrba/compare/v2.2.0...v2.2.1) - 2025-12-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yrba"
 description = "Incremental remote backups made simple!"
 authors = ["Lilith Roth <lilith@roth.systems>"]
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 2.2.1 -> 2.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.2.2](https://github.com/lilith-roth/yrba/compare/v2.2.1...v2.2.2) - 2025-12-05

### Fixed

- *(systemd)* service description broken
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).