### PR TITLE
chore: release v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.3](https://github.com/lilith-roth/yrba/compare/v2.2.2...v2.2.3) - 2025-12-26
+
+### Added
+
+- smb with non-standard ports
+
+### Other
+
+- integration tests
+- *(deps)* bump actions/upload-artifact from 5 to 6 ([#103](https://github.com/lilith-roth/yrba/pull/103))
+- *(deps)* bump docker/metadata-action from 8d8c7c12f7b958582a5cb82ba16d5903cb27976a to c299e40c65443455700f0fdfc63efafe5b349051 ([#101](https://github.com/lilith-roth/yrba/pull/101))
+- *(deps)* bump actions/checkout from 4.3.1 to 6.0.1 ([#100](https://github.com/lilith-roth/yrba/pull/100))
+- *(github)* improved issue templates
+
 ## [2.2.2](https://github.com/lilith-roth/yrba/compare/v2.2.1...v2.2.2) - 2025-12-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yrba"
 description = "Incremental remote backups made simple!"
 authors = ["Lilith Roth <lilith@roth.systems>"]
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 2.2.2 -> 2.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.2.3](https://github.com/lilith-roth/yrba/compare/v2.2.2...v2.2.3) - 2025-12-26

### Added

- smb with non-standard ports

### Other

- integration tests
- *(deps)* bump actions/upload-artifact from 5 to 6 ([#103](https://github.com/lilith-roth/yrba/pull/103))
- *(deps)* bump docker/metadata-action from 8d8c7c12f7b958582a5cb82ba16d5903cb27976a to c299e40c65443455700f0fdfc63efafe5b349051 ([#101](https://github.com/lilith-roth/yrba/pull/101))
- *(deps)* bump actions/checkout from 4.3.1 to 6.0.1 ([#100](https://github.com/lilith-roth/yrba/pull/100))
- *(github)* improved issue templates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).