### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0](https://github.com/lilith-roth/yrba/compare/v2.3.0...v2.4.0) - 2026-05-07
+
+### Added
+
+- sftp configurable file buffer ([#127](https://github.com/lilith-roth/yrba/pull/127))
+
+### Other
+
+- dep update ([#116](https://github.com/lilith-roth/yrba/pull/116))
+
 ## [2.3.0](https://github.com/lilith-roth/yrba/compare/v2.2.3...v2.3.0) - 2026-05-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "yrba"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yrba"
 description = "Incremental remote backups made simple!"
 authors = ["Lilith Roth <lilith@roth.systems>"]
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/yrba"


### PR DESCRIPTION



## 🤖 New release

* `yrba`: 2.3.0 -> 2.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.4.0](https://github.com/lilith-roth/yrba/compare/v2.3.0...v2.4.0) - 2026-05-07

### Added

- sftp configurable file buffer ([#127](https://github.com/lilith-roth/yrba/pull/127))

### Other

- dep update ([#116](https://github.com/lilith-roth/yrba/pull/116))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).