### PR TITLE
feat: Use ISO 8601 datetime strings in backup names

### DIFF
--- a/src/upload/protocols/smb.rs
+++ b/src/upload/protocols/smb.rs
@@ -95,6 +95,13 @@ pub(crate) async fn upload_smb(file_path: &Path, config: &Config) -> anyhow::Res
     Ok(())
 }
 
+/// Generates a file name for the backup that complies with windows' arbitrary arcane file name
+/// restrictions.
+fn generate_windows_compatible_backup_name(backup_name: &Path) -> anyhow::Result<String> {
+    // ':' is a reserved character under windows. blegh
+    generate_backup_name(backup_name).map(|name| name.replace(':', "-"))
+}
+
 /// Uploads the backup, to be called by `upload_smb` above
 ///
 /// # Arguments
@@ -107,7 +114,7 @@ async fn upload_backup(
     remote_address: Host<&str>,
     client: &Client,
 ) -> anyhow::Result<()> {
-    let backup_name: &String = &generate_backup_name(file_path)?;
+    let backup_name: &String = &generate_windows_compatible_backup_name(file_path)?;
     let file_to_open: UncPath = target_path.to_owned().with_add_path(backup_name);
     log::debug!("Backup path {file_to_open}");
 

--- a/src/upload/utils/file_name.rs
+++ b/src/upload/utils/file_name.rs
@@ -9,7 +9,7 @@ pub fn generate_backup_name(backup_name: &Path) -> anyhow::Result<String> {
             .ok_or_else(|| anyhow!("Could not generate backup file name!"))?
             .to_string_lossy()
             .replace(".tar.gz", ""),
-        chrono::offset::Local::now().format("%Y-%m-%d_%H-%M")
+        chrono::offset::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
     );
     Ok(backup_name)
 }


### PR DESCRIPTION
For the sake of standardization, yrba should use ISO 8601 datetime strings to date backups. In particular, this PR changes the backup names to look like this:

```
some-file--2026-21-05T12:08:56Z.tar.gz
```

The caveat here is that this doesn't work on windows hosts, because windows reserves ':' as a special character in file names. Because of this, this PR uses '-' instead of ':' in file names (so e.g. `some-file--2026-21-05T12-08-56Z.tar.gz`) when using the smb protocol.

This does however mean that other protocols, such as sftp, will also fail on windows hosts. In the long term it might make sense to do one or more of the following:
- Somehow automatically detect the host's OS and adjust the file names accordingly
- Make the file name format configurable, potentially with presets
- Save ourselves the suffering and drop windows support /hj