### PR TITLE
fix: change systemd unit type to oneshot

### DIFF
--- a/systemd/yrba.service
+++ b/systemd/yrba.service
@@ -5,6 +5,7 @@ StartLimitIntervalSec=10min
 StartLimitBurst=2
 
 [Service]
+Type=oneshot
 ExecStart=/usr/bin/yrba -c /etc/yrba.toml
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
The systemd unit type should be oneshot rather than simple, since the process is expected to exit after finishing.